### PR TITLE
added Ndef.bytesToHexString() method to return IDs in a more common forma

### DIFF
--- a/phonegap-nfc.js
+++ b/phonegap-nfc.js
@@ -129,6 +129,24 @@ var Ndef = {
         }
         // return an array of bytes
         return re;
+    },
+
+    bytesToHexString: function (bytes) {
+      var bytesAsHexString = "";
+      for (var i = 0; i < bytes.length; i++) {
+        if(bytes[i] >= 0) {
+          dec = bytes[i];
+        } else {
+          dec = 256 + bytes[i];
+        }
+        hexstring = dec.toString(16);
+        // zero padding
+        if(hexstring.length == 1) {
+          hexstring = "0" + hexstring;
+        }
+        bytesAsHexString += hexstring;
+      }
+      return bytesAsHexString;
     }
     
 };


### PR DESCRIPTION
added Ndef.bytesToHexString() method to return IDs in a more common format

So basically, I just added a bytesToHexString helper since that's the type of identifier (8 digit hex string) that's more commonly used - the identifier usually printed on wristbands, etc.
