### PR TITLE
workaround for ICS bug returning null from mTag.getTagService()

### DIFF
--- a/src/com/chariotsolutions/nfc/plugin/Util.java
+++ b/src/com/chariotsolutions/nfc/plugin/Util.java
@@ -25,8 +25,15 @@ public class Util {
                 json.put("type", translateType(ndef.getType()));
                 json.put("maxSize", ndef.getMaxSize());
                 json.put("isWritable", ndef.isWritable());
-                json.put("canMakeReadOnly", ndef.canMakeReadOnly());
                 json.put("ndefMessage", messageToJSON(ndef.getCachedNdefMessage()));
+                // Workaround for bug in ICS (Android 4.0 and 4.0.1) where
+                // mTag.getTagService(); of the Ndef object sometimes returns null
+                // see http://issues.mroland.at/index.php?do=details&task_id=47
+                try {
+                  json.put("canMakeReadOnly", ndef.canMakeReadOnly());
+                } catch (NullPointerException e) {
+                  json.put("canMakeReadOnly", null);
+                }
             } catch (JSONException e) {
                 Log.e(TAG, "Failed to convert ndef into json: " + ndef.toString(), e);
             }


### PR DESCRIPTION
Plugin kept crashing about 9 times out of 10 on my Galaxy Nexus ICS 4.0.2 when reading a tag. Based on [this](http://issues.mroland.at/index.php?do=details&task_id=47) post, this is caused by a bug on ICS. 

Added a try/catch around `ndef.canMakeReadOnly()` call, which solves the problem for me.
