### PR TITLE
Add the javascript device.nfc variable

### DIFF
--- a/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -119,6 +119,10 @@ public class NfcPlugin extends Plugin {
 
         } else if (action.equalsIgnoreCase(INIT)) {
             Log.d(TAG, "Enabling plugin " + getIntent());
+            
+            if(!checkNfcSupport()){
+                return new PluginResult(Status.ERROR);
+            }
 
             startNfc();
             if (!recycledIntent()) {
@@ -151,6 +155,17 @@ public class NfcPlugin extends Plugin {
 
     private void addTagFilter() {
         intentFilters.add(new IntentFilter(NfcAdapter.ACTION_TAG_DISCOVERED));
+    }
+    
+    private boolean checkNfcSupport(){
+        NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(getActivity());
+
+        if (nfcAdapter != null && nfcAdapter.isEnabled()) {
+            // adapter exists and is enabled.
+            return true;
+        }
+
+        return false;
     }
 
     private void startNfc() {

--- a/www/phonegap-nfc.js
+++ b/www/phonegap-nfc.js
@@ -4,10 +4,12 @@ cordova.addConstructor(
     function () {
         cordova.exec(
             function () {
+                device.nfc = true;
                 console.log("Initialized the NfcPlugin");
             },
             function (reason) {
-                alert("Failed to initialize the NfcPlugin " + reason);
+                device.nfc = false;
+                console.log("Failed to initialize the NfcPlugin " + reason);
             },
             "NfcPlugin", "init", []
         );


### PR DESCRIPTION
Adds the javascript variable "nfc" to the "device" object to allow other
code to check if the NFC plugin was successfully initalized and if the
phone supports NFC.
If the phone has NFC support, then the variable device.nfc will be true,
false otherwise.

Note: a real phone support check has been only added to Android.
