### PR TITLE
replaced Java null by JSONObject.NULL as recommended in JSON libraray, b...

### DIFF
--- a/src/android/src/com/chariotsolutions/nfc/plugin/Util.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/Util.java
@@ -40,7 +40,7 @@ public class Util {
                 try {
                   json.put("canMakeReadOnly", ndef.canMakeReadOnly());
                 } catch (NullPointerException e) {
-                  json.put("canMakeReadOnly", null);
+                  json.put("canMakeReadOnly", JSONObject.NULL);
                 }
             } catch (JSONException e) {
                 Log.e(TAG, "Failed to convert ndef into json: " + ndef.toString(), e);


### PR DESCRIPTION
I have a project setup, which is using maven for building and testing code. Using the plugin the maven compiler plugin complains about ambiguous in the put method. After reading the javadoc of the JSON libraray it is recommended to use NULL instead of Java null.

http://www.json.org/javadoc/org/json/JSONObject.html

the changes solved the compiler problem
