### PR TITLE
Prevent annoying 'NfcPlugin not found' console messages on iOS

### DIFF
--- a/www/phonegap-nfc.js
+++ b/www/phonegap-nfc.js
@@ -10,7 +10,7 @@ function handleNfcFromIntentFilter() {
     // addConstructor was finishing *before* deviceReady was complete and the
     // ndef listeners had not been registered.
     // It seems like there should be a better solution.
-    if (cordova.platformId !== "blackberry10") {
+    if (cordova.platformId !== "blackberry10" && cordova.platformId !== "ios") {
         setTimeout(
             function () {
                 cordova.exec(


### PR DESCRIPTION
I know this plugin is not for iOS, but I use it on an app which supports both Android and iOS, and want to get rid of the annoying console messages.
