### PR TITLE
re-add callback parameter to remove ndef listener

### DIFF
--- a/www/phonegap-nfc.js
+++ b/www/phonegap-nfc.js
@@ -429,7 +429,7 @@ var nfc = {
         cordova.exec(win, fail, "NfcPlugin", "removeMimeType", [mimeType]);
     },
 
-    removeNdefListener: function (win, fail) {
+    removeNdefListener: function (callback, win, fail) {
         document.removeEventListener("ndef", callback, false);
         cordova.exec(win, fail, "NfcPlugin", "removeNdef", []);
     }


### PR DESCRIPTION
The function removeNdefListener was missing a callback parameter which caused an exception to be thrown when the function was called.
