### PR TITLE
a dedicated interface to get current nfc device status

### DIFF
--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -47,7 +47,7 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
     private static final String UNSHARE_TAG = "unshareTag";
     private static final String HANDOVER = "handover"; // Android Beam
     private static final String STOP_HANDOVER = "stopHandover";
-    private static final String GET_STATUS = "getStatus";
+    private static final String ENABLED = "enabled";
     private static final String INIT = "init";
 
     private static final String NDEF = "ndef";
@@ -74,8 +74,8 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
 
     @Override
     public boolean execute(String action, JSONArray data, CallbackContext callbackContext) throws JSONException {
-        
-        if (action.equalsIgnoreCase(GET_STATUS)) {
+    
+        if (action.equalsIgnoreCase(ENABLED)) {
           callbackContext.success(getNfcStatus());
           return true;
         }

--- a/www/phonegap-nfc.js
+++ b/www/phonegap-nfc.js
@@ -418,9 +418,9 @@ var nfc = {
     erase: function (win, fail) {
         cordova.exec(win, fail, "NfcPlugin", "eraseTag", [[]]);
     },
-    
-    getStatus: function (win, fail) {
-        cordova.exec(win, fail, "NfcPlugin", "getStatus", [[]]);
+
+    enabled: function (win, fail) {
+        cordova.exec(win, fail, "NfcPlugin", "enabled", [[]]);
     },
 
     removeTagDiscoveredListener: function (callback, win, fail) {


### PR DESCRIPTION
often there is a requirement to tell the user to activate the NFC option before he can proceed any action

if he switched off the NFC, for power save for example, while the app is in the background, then after resume we have to know whether the NFC is still ON or OFF to react accordingly

for this reason there have to be an interface to get on/off status of the NFC device
