### PR TITLE
Update phonegap-nfc.js

### DIFF
--- a/www/phonegap-nfc.js
+++ b/www/phonegap-nfc.js
@@ -432,7 +432,16 @@ var nfc = {
     removeNdefListener: function (callback, win, fail) {
         document.removeEventListener("ndef", callback, false);
         cordova.exec(win, fail, "NfcPlugin", "removeNdef", []);
+    },
+    readMifare: function (win, fail) {
+        
+        cordova.exec(win, fail, "NfcPlugin", "readMf", []);
+    },
+    readMifareSecBloc: function (sector,bloque,win, fail) {
+        
+        cordova.exec(win, fail, "NfcPlugin", "readMf_SB", [sector,bloque]);
     }
+    
 
 };
 


### PR DESCRIPTION
add 2 funtion for read mifare classic card 

readMifare: return all data separating sector by | and block by ;

readMifareSecBloc: return the data from an especific sector and block

example call

nfc.readMifare(leeMF,noleeMF);
nfc.readMifareSecBloc(1,2,leeMF,noleeMF);
