### PR TITLE
show debug message only in debug apk

### DIFF
--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -74,8 +74,10 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
 
     @Override
     public boolean execute(String action, JSONArray data, CallbackContext callbackContext) throws JSONException {
-
-        Log.d(TAG, "execute " + action);
+        
+        if (BuildConfig.DEBUG) {
+          Log.d(TAG, "execute " + action);
+        }
 
         if (!getNfcStatus().equals(STATUS_NFC_OK)) {
             callbackContext.error(getNfcStatus());


### PR DESCRIPTION
Log.d is used to print debug messages, the message is printed not only in the debug version of the apk but also in the release, which is not 	desirable

to show the message only in the debug version I created this PR