### PR TITLE
remove import to allow compile

### DIFF
--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -6,9 +6,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-// using wildcard imports so we can support Cordova 3.x and Cordova 2.9
+// using wildcard imports so we can support Cordova 3.x
 import org.apache.cordova.*; // Cordova 3.x
-import org.apache.cordova.api.*;  // Cordova 2.9
 
 import org.json.JSONArray;
 import org.json.JSONException;


### PR DESCRIPTION
Since last version drops support for Cordova 2.9 it doesn't compile.
Not sure if this pr is correct, but at least compiles