### PR TITLE
addNdefListener not calling callback on first attempt

### DIFF
--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -617,7 +617,7 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
                 if (action.equals(NfcAdapter.ACTION_NDEF_DISCOVERED)) {
                     Ndef ndef = Ndef.get(tag);
                     fireNdefEvent(NDEF_MIME, ndef, messages);
-
+                    fireNdefEvent(NDEF, ndef, messages); //MIME records are a subtype of NDEF records, so fire the NDEF event as well.
                 } else if (action.equals(NfcAdapter.ACTION_TECH_DISCOVERED)) {
                     for (String tagTech : tag.getTechList()) {
                         Log.d(TAG, tagTech);


### PR DESCRIPTION
FIX for issue 217: addNdefListener not calling callback on first attempt

I don't know why the Intent contains the ACTION_NDEF_DISCOVERED when reading non-MIME NDEF records the first time.
After the first read, the action contains the  ACTION_TECH_DISCOVERED as expected.

Even if this behavior were not the plugin's fault, it does make sense to fire the "ndef" event when reading MIME records in adition to the "ndef-mime" event, because if we have registered a callback with `addNdefListener`, then we want to be called back on every subtype of NDEF record.
