### PR TITLE
fixed language code field length detection

### DIFF
--- a/www/phonegap-nfc.js
+++ b/www/phonegap-nfc.js
@@ -641,7 +641,7 @@ var textHelper = {
 
     decodePayload: function (data) {
 
-        var languageCodeLength = (data[0] & 0x1F), // 5 bits
+        var languageCodeLength = (data[0] & 0x3F), // 6 LSBs
             languageCode = data.slice(1, 1 + languageCodeLength),
             utf16 = (data[0] & 0x80) !== 0; // assuming UTF-16BE
 


### PR DESCRIPTION
In Well Known NDEF records of RTD "Text", the first byte in the payload is the status byte. This byte contains, according to the spec:

| bit number (0 is LSB)  | Content                    |
| ---------------------- | -------------------------- |
| 7  | 0 for UTF-8, 1 for UTF-16  |
| 6  | RFU (MUST be set to zero) |
| 5..0  | The length of the IANA language code.  |

So it is not 5 bits, but bits 5 to 0.

Source: NFC Forum Text Record Type Definition Technical Specification, p.4