### PR TITLE
Replace deprecated CordovaWebView.sendJavascript with alternate method

### DIFF
--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -646,7 +646,7 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
 
         String command = MessageFormat.format(javaScriptEventTemplate, type, tag);
         Log.v(TAG, command);
-        this.webView.sendJavascript(command);
+        sendJavascript(command);
 
     }
 
@@ -654,14 +654,14 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
 
         String command = MessageFormat.format(javaScriptEventTemplate, NDEF_FORMATABLE, Util.tagToJSON(tag));
         Log.v(TAG, command);
-        this.webView.sendJavascript(command);
+        sendJavascript(command);
     }
 
     private void fireTagEvent (Tag tag) {
 
         String command = MessageFormat.format(javaScriptEventTemplate, TAG_DEFAULT, Util.tagToJSON(tag));
         Log.v(TAG, command);
-        this.webView.sendJavascript(command);
+        sendJavascript(command);
     }
 
     JSONObject buildNdefJSON(Ndef ndef, Parcelable[] messages) {
@@ -763,4 +763,9 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
         }
 
     }
+	
+	//WORKAROUND: CordovaWebView.sendJavascript is deprecated and no longer works in Cordova 5 with pre KitKat devices.
+    private void sendJavascript(final String js) {
+		webView.loadUrl("javascript:" + js);
+	}
 }


### PR DESCRIPTION
The CordovaWebView.sendJavascript method is deprecated, and using it in pre KitKat devices with the latest Cordova 5.1 version throws an error during plugin initialization. The error is not observable in Lollipop and newer devices, and never happened when using previous Cordova versions (3.7).
