### PR TITLE
NFC events not firing on first scan  Fixes #217 (and others)

### DIFF
--- a/www/phonegap-nfc.js
+++ b/www/phonegap-nfc.js
@@ -841,7 +841,7 @@ require('cordova/channel').onCordovaReady.subscribe(function() {
     if (!message.type) { 
         console.log(message);
     } else {
-        console.log('Received NFC data, firing event');
+        console.log("Received NFC data, firing '" + message.type + "' event");
         var e = document.createEvent('Events');
         e.initEvent(message.type)
         e.tag = message.tag;


### PR DESCRIPTION
1. Don't start the NFC foreground dispatching if no listeners have been added
2. Restart the NFC foreground dispatching any time the intent filters or tech lists are modified