### PR TITLE
Fix issue AndroidManifest.xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phonegap-nfc",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Near Field Communication (NFC) Plugin. Read and write NDEF messages to NFC tags and share NDEF messages with peers.",
   "cordova": {
     "id": "phonegap-nfc",

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,10 +36,6 @@
             <uses-feature android:name="android.hardware.nfc" android:required="false"/>
         </config-file>
 
-        <edit-config file="AndroidManifest.xml" target="/manifest/uses-sdk" mode="merge">
-            <uses-sdk android:minSdkVersion="19" />
-        </edit-config>
-
     </platform>
 
     <platform name="wp8">


### PR DESCRIPTION
When using with ionic 4, there is a preference:

<preference name="android-minSdkVersion" value="19" />

and it gets merged into the AndroidManifest.xml, so when you try to install this plugin, there is a conflict and an error with the xml parsing:

`Error: Unable to graft xml at selector "/manifest/uses-sdk" from "platforms\android\app\src\main\AndroidManifest.xml" during config install at ConfigFile_graft_child [as graft_child]`

This fix removes the extra configuration setting for the AndriodManifest so it doesn't cause conflict.