### PR TITLE
Prevent crash in connect() when both intent and savedIntent are null

### DIFF
--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -856,7 +856,7 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
             try {
 
                 Tag tag = getIntent().getParcelableExtra(NfcAdapter.EXTRA_TAG);
-                if (tag == null) {
+                if (tag == null && savedIntent != null) {
                     tag = savedIntent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
                 }
 


### PR DESCRIPTION
When no intent has been received yet, the connect() function causes
a crash of the application due to a null pointer exception on Android.

Fix by introducing a null check.