### PR TITLE
Allow connecting to tags discovered in readerMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ Connect to the tag and enable I/O operations to the tag from this TagTechnology 
 
 ### Description
 
-Function `connect` enables I/O operations to the tag from this TagTechnology object. `nfc.connect` should be called after receiving a nfcEvent from the `addTagDiscoveredListener`. Only one TagTechnology object can be connected to a Tag at a time.
+Function `connect` enables I/O operations to the tag from this TagTechnology object. `nfc.connect` should be called after receiving a nfcEvent from the `addTagDiscoveredListener` or the `readerMode` callback. Only one TagTechnology object can be connected to a Tag at a time.
 
 See Android's [TagTechnology.connect()](https://developer.android.com/reference/android/nfc/tech/TagTechnology.html#connect()) for more info.
 

--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -244,6 +244,10 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
                 json = Util.tagToJSON(tag);
             }
 
+            Intent tagIntent = new Intent();
+            tagIntent.putExtra(NfcAdapter.EXTRA_TAG, tag);
+            setIntent(tagIntent);
+
             PluginResult result = new PluginResult(PluginResult.Status.OK, json);
             result.setKeepCallback(true);
             readerModeCallback.sendPluginResult(result);


### PR DESCRIPTION
Currently, connect() does not work in readerMode on Android since
no intent will be set when discovering a tag and, consequently,
connect() does not know which tag to connect to.

Allow connections in readerMode by setting an intent from within
the reader mode callback.