### PR TITLE
Return the tag tech's max transceive length after connect()

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ See Android's [TagTechnology.connect()](https://developer.android.com/reference/
 
 ### Returns
 
- - Promise when the connection is successful
+ - Promise when the connection is successful, optionally with a maxTransceiveLength attribute in case the tag technology supports it
 
 ### Quick Example
 

--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -866,6 +866,8 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
                     return;
                 }
 
+                JSONObject resultObject = new JSONObject();
+
                 // get technologies supported by this tag
                 List<String> techList = Arrays.asList(tag.getTechList());
                 if (techList.contains(tech)) {
@@ -873,6 +875,16 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
                     tagTechnologyClass = Class.forName(tech);
                     Method method = tagTechnologyClass.getMethod("get", Tag.class);
                     tagTechnology = (TagTechnology) method.invoke(null, tag);
+
+                    // If the tech supports it, return maxTransceiveLength and return it to the user
+                    try {
+                        Method maxTransceiveLengthMethod = tagTechnologyClass.getMethod("getMaxTransceiveLength");
+                        resultObject.put("maxTransceiveLength", maxTransceiveLengthMethod.invoke(tagTechnology));
+                    } catch(NoSuchMethodException e) {
+                        // Some technologies do not support this, so just ignore.
+                    } catch(JSONException e) {
+                        Log.e(TAG, "Error serializing JSON", e);
+                    }
                 }
 
                 if (tagTechnology == null) {
@@ -882,7 +894,7 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
 
                 tagTechnology.connect();
                 setTimeout(timeout);
-                callbackContext.success();
+                callbackContext.success(resultObject);
 
             } catch (IOException ex) {
                 Log.e(TAG, "Tag connection failed", ex);


### PR DESCRIPTION
For many transceive operations, it is crucial to know the maximum transceive
length supported by the NFC hardware / stack.

This patch provides the maximum transceive length as part of the connect()
result in case it is supported by the tag technology.