### PR TITLE
Hotfix for chariotsolutions#363 (from bushev@00fd9c1)

### DIFF
--- a/src/ios/NfcPlugin.h
+++ b/src/ios/NfcPlugin.h
@@ -15,6 +15,7 @@
 }
 
 // iOS Specific API
+- (void)channel:(CDVInvokedUrlCommand *)command;
 - (void)beginSession:(CDVInvokedUrlCommand *)command;
 - (void)invalidateSession:(CDVInvokedUrlCommand *)command;
 

--- a/src/ios/NfcPlugin.m
+++ b/src/ios/NfcPlugin.m
@@ -29,6 +29,11 @@
 
 #pragma mark -= Cordova Plugin Methods
 
+// TODO: Hotfix for https://github.com/chariotsolutions/phonegap-nfc/issues/363
+- (void)channel:(CDVInvokedUrlCommand*)command {
+    NSLog(@"channel :-)");
+}
+
 // Unfortunately iOS users need to start a session to read tags
 - (void)beginSession:(CDVInvokedUrlCommand*)command {
     NSLog(@"beginSession");

--- a/www/phonegap-nfc.js
+++ b/www/phonegap-nfc.js
@@ -21,7 +21,7 @@ function handleNfcFromIntentFilter() {
                     },
                     "NfcPlugin", "init", []
                 );
-            }, 10
+            }, 100
         );
     }
 }

--- a/www/phonegap-nfc.js
+++ b/www/phonegap-nfc.js
@@ -21,7 +21,7 @@ function handleNfcFromIntentFilter() {
                     },
                     "NfcPlugin", "init", []
                 );
-            }, 100
+            }, 10
         );
     }
 }


### PR DESCRIPTION
Hotfix for chariotsolutions#363 (Method 'channel:' not defined in Plugin 'NfcPlugin'), as suggested in [bushev@ea08e52](https://github.com/bushev/device-com-nfc.cordova/commit/ea08e52a1c9395e387c5006fa51dcb6e24d15496)