### PR TITLE
Notify Cordova on Successful Tag Write

### DIFF
--- a/src/ios/NfcPlugin.m
+++ b/src/ios/NfcPlugin.m
@@ -378,6 +378,8 @@
                     [self closeSession:session withError:@"Write failed."];
                 } else {
                     session.alertMessage = @"Wrote data to NFC tag.";
+                    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+                    [self.commandDelegate sendPluginResult:pluginResult callbackId:self->sessionCallbackId];
                     [self closeSession:session];
                 }
             }];


### PR DESCRIPTION
Hi!

Thank you for this library, it works really well so far.
When using the `nfc.write` method on an iOS device, I expected the [onSuccess] function to be called after a successful write. This does not seem to be the case in the newest version of this library and I assume that it was not intended to be this way.  In an error case however, the Plugin is provided with an error message. Looking into the code I noticed that the session is closed and the callbackId is removed before writing any success message, so the Plugin part is never notified about a successful write.

In this pull request I send an empty `CDVPluginResult` on a successful write. Let me know if there if there is anything else you want me to or provide, or if maybe I just misunderstood the usage of `nfc.write`.