### PR TITLE
Fix null pointer exception and possible crash

### DIFF
--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -250,7 +250,11 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
 
             PluginResult result = new PluginResult(PluginResult.Status.OK, json);
             result.setKeepCallback(true);
-            readerModeCallback.sendPluginResult(result);
+            if (readerModeCallback != null) {
+                readerModeCallback.sendPluginResult(result);
+            } else {
+                Log.i(TAG, "readerModeCallback is null - reader mode probably disabled in the meantime");
+            }
 
         }
     };

--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -998,6 +998,10 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
                 String error = "TagTechnology " + tagTechnologyClass.getName() + " does not have a transceive function";
                 Log.e(TAG, error, e);
                 callbackContext.error(error);
+            } catch (NullPointerException e) {
+                // This can happen if the tag has been closed while we're still working with it from the thread pool.
+                Log.e(TAG, e.getMessage(), e);
+                callbackContext.error(e.getMessage());
             } catch (IllegalAccessException e) {
                 Log.e(TAG, e.getMessage(), e);
                 callbackContext.error(e.getMessage());


### PR DESCRIPTION
This fixes an issue where a null pointer exception is thrown when onTagDiscovered is fired shortly after reader mode is disabled.

Also catches and gracefully handles a NPE which can occur when we're working with a tag from the thread pool after it has already been closed.