### PR TITLE
Use correct key for NDEF Record identifier in writeTag for iOS

### DIFF
--- a/src/ios/NfcPlugin.m
+++ b/src/ios/NfcPlugin.m
@@ -105,7 +105,7 @@
             NSNumber *tnfNumber = [recordData objectForKey:@"tnf"];
             NFCTypeNameFormat tnf = (uint8_t)[tnfNumber intValue];
             NSData *type = [self uint8ArrayToNSData:[recordData objectForKey:@"type"]];
-            NSData *identifier = [self uint8ArrayToNSData:[recordData objectForKey:@"identifiers"]];
+            NSData *identifier = [self uint8ArrayToNSData:[recordData objectForKey:@"id"]];
             NSData *payload  = [self uint8ArrayToNSData:[recordData objectForKey:@"payload"]];
             NFCNDEFPayload *record = [[NFCNDEFPayload alloc] initWithFormat:tnf type:type identifier:identifier payload:payload];
             [payloads addObject:record];


### PR DESCRIPTION
When writing tags from iOS, we noticed the identifier of the NDEF Record is not written.
After some investigation we noticed the wrong key was being used to retrieve the identifier from the `recordData`.
This PR fixes this.