### PR TITLE
Fix NFCTagReaderSession init unavailable in SDK 14.5

### DIFF
--- a/src/ios/NfcPlugin.m
+++ b/src/ios/NfcPlugin.m
@@ -125,13 +125,13 @@
         if (self.shouldUseTagReaderSession) {
             NSLog(@"Using NFCTagReaderSession");
 
-            self.nfcSession = [[NFCTagReaderSession new]
+            self.nfcSession = [[NFCTagReaderSession alloc]
                        initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693)
                        delegate:self queue:dispatch_get_main_queue()];
 
         } else {
             NSLog(@"Using NFCTagReaderSession");
-            self.nfcSession = [[NFCNDEFReaderSession new]initWithDelegate:self queue:nil invalidateAfterFirstRead:FALSE];
+            self.nfcSession = [[NFCNDEFReaderSession alloc]initWithDelegate:self queue:nil invalidateAfterFirstRead:FALSE];
         }
     }
 
@@ -306,12 +306,12 @@
         
         if (self.shouldUseTagReaderSession) {
             NSLog(@"Using NFCTagReaderSession");
-            self.nfcSession = [[NFCTagReaderSession new]
+            self.nfcSession = [[NFCTagReaderSession alloc]
                            initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693)
                            delegate:self queue:dispatch_get_main_queue()];
         } else {
             NSLog(@"Using NFCNDEFReaderSession");
-            self.nfcSession = [[NFCNDEFReaderSession new]initWithDelegate:self queue:nil invalidateAfterFirstRead:TRUE];
+            self.nfcSession = [[NFCNDEFReaderSession alloc]initWithDelegate:self queue:nil invalidateAfterFirstRead:TRUE];
         }
         sessionCallbackId = [command.callbackId copy];
         self.nfcSession.alertMessage = @"Hold near NFC tag to scan.";
@@ -319,7 +319,7 @@
         
     } else if (@available(iOS 11.0, *)) {
         NSLog(@"iOS < 13, using NFCNDEFReaderSession");
-        self.nfcSession = [[NFCNDEFReaderSession new]initWithDelegate:self queue:nil invalidateAfterFirstRead:TRUE];
+        self.nfcSession = [[NFCNDEFReaderSession alloc]initWithDelegate:self queue:nil invalidateAfterFirstRead:TRUE];
         sessionCallbackId = [command.callbackId copy];
         self.nfcSession.alertMessage = @"Hold near NFC tag to scan.";
         [self.nfcSession beginSession];


### PR DESCRIPTION
Since iPhoneOS14.5 the init function has been marked as unavailable.

Example error:

```
 /usr/local/opt/actions-runner/_work/mobile-app/mobile-app/platforms/ios/Leviy/Plugins/phonegap-nfc/NfcPlugin.m:128:53: error: 'new' is unavailable
            self.nfcSession = [[NFCTagReaderSession new]
                                                    ^
In module 'CoreNFC' imported from /usr/local/opt/actions-runner/_work/mobile-app/mobile-app/platforms/ios/Leviy/Plugins/phonegap-nfc/NfcPlugin.h:11:
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.5.sdk/System/Library/Frameworks/CoreNFC.framework/Headers/NFCTagReaderSession.h:100:1: note: 'init' has been explicitly marked unavailable here
- (instancetype)init NS_UNAVAILABLE;
^
```

Fixes https://github.com/chariotsolutions/phonegap-nfc/issues/448