### PR TITLE
Android: Improved support for background launch in Android and iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1280,6 +1280,44 @@ We have found it necessary to add `android:noHistory="true"` to the activity ele
 
 See the Android documentation for more information about [filtering for NFC intents](http://developer.android.com/guide/topics/connectivity/nfc/nfc.html#ndef-disc).
 
+## Accessing Tag information during application launch
+
+If your application is launched because an NFC tag was read, the intent passed to your main activity will be the `LAUNCH` intent, rather than one of the NFC tag intents (e.g. `NDEF_DISCOVERED`). In order to capture the NFC tag intent that was used to launch your application, you need to associate the NFC tag intent filter with an activity other than Cordova's `MainActivity`.
+
+You can do this following these steps:
+
+1. Add a section to your `AndroidManifest.xml` file with the appropriate NFC `intent-filter` that points to the activity `com.chariotsolutions.nfc.plugin.NfcActivity`. 
+ * If you are developing in a multi-platform environment, you can do this by adding the following to your `config.xml`:
+
+```xml
+<platform name="android">
+    <config-file parent="/manifest/application" target="AndroidManifest.xml">
+        <activity android:label="NfcActivity" android:launchMode="singleTask" android:name="com.chariotsolutions.nfc.plugin.NfcActivity" android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <!-- Replace the following with a filter that applies to your app -->
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:host="myapp.com" android:pathPrefix="/nfc" android:scheme="https" />
+            </intent-filter>
+        </activity>
+    </config-file>
+</platform>
+```
+
+2. On your app, during or after the Cordova `deviceready` event, call the `parseLaunchIntent` function, for example:
+
+```javascript
+document.addEventListener("deviceready", onDeviceReady, false);
+
+function onDeviceReady() {
+    nfc.parseLaunchIntent(function(tag) {
+        console.log('Application was launched with tag: ' + JSON.stringify(tag));
+    });
+}
+```
+
+The above will work whether your app was launched for the first time or simply brought to the foreground.
+
 Testing
 =======
 

--- a/README.md
+++ b/README.md
@@ -1264,6 +1264,46 @@ Or to scan only Plain Text tags use
 
 See the [BlackBerry documentation](http://developer.blackberry.com/native/documentation/cascades/device_comm/nfc/receiving_content.html) for more info.
 
+# Launching your iOS Application when Scanning a Tag
+
+On iOS, your application can be launched when an NFC tag is read, if the tag contains an NDEF message with a Universal Link (URL). This is optional and requires configuration on your application entitlements. The Universal Link needs to point to an actual HTTPS server that contains an `apple-app-site-association` that links the URL with your app.
+
+In a nutshell, you need to:
+
+1. Setup an associated domain relationship between your app and the Universal Link URL of your choosing. See: https://developer.apple.com/documentation/xcode/supporting-associated-domains
+
+2. Add an associated domain entitlement to your app in XCode. See: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_associated-domains
+  * If you are developing in a multi-platform environment, you can do this by adding the following to your `config.xml`:
+
+```xml
+<platform name="ios">
+    <config-file parent="com.apple.developer.associated-domains" platform="ios" target="*-Debug.plist">
+        <array>
+            <string>applinks:myapp.com</string>
+        </array>
+    </config-file>
+    <config-file parent="com.apple.developer.associated-domains" platform="ios" target="*-Release.plist">
+        <array>
+            <string>applinks:myapp.com</string>
+        </array>
+    </config-file>
+</platform>
+```
+
+3. On your app, during or after the Cordova `deviceready` event, call the `parseLaunchIntent` plugin function, for example:
+
+```javascript
+document.addEventListener("deviceready", onDeviceReady, false);
+
+function onDeviceReady() {
+    nfc.parseLaunchIntent(function(tag) {
+        console.log('Application was launched with tag: ' + JSON.stringify(tag));
+    });
+}
+```
+
+  * You may want to do the same on the `onresume` event to support the case where your app was already running in the background.
+
 # Launching your Android Application when Scanning a Tag
 
 On Android, intents can be used to launch your application when a NFC tag is read.  This is optional and configured in AndroidManifest.xml.
@@ -1316,7 +1356,7 @@ function onDeviceReady() {
 }
 ```
 
-The above will work whether your app was launched for the first time or simply brought to the foreground.
+ * You may want to do the same on the `onresume` event to support the case where your app was already running in the background.
 
 Testing
 =======

--- a/README.md
+++ b/README.md
@@ -452,7 +452,6 @@ Function `nfc.share` writes an NdefMessage via peer-to-peer.  This should appear
 
 ### Supported Platforms
 
-- Android
 - Windows
 - BlackBerry 7
 - BlackBerry 10
@@ -481,7 +480,6 @@ Function `nfc.unshare` stops sharing data via peer-to-peer.
 
 ### Supported Platforms
 
-- Android
 - Windows
 - BlackBerry 7
 - BlackBerry 10

--- a/plugin.xml
+++ b/plugin.xml
@@ -122,12 +122,14 @@
         <!-- https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_nfc_readersession_formats?language=objc -->
         <config-file parent="com.apple.developer.nfc.readersession.formats" platform="ios" target="*-Debug.plist">
             <array>
-                <string>TAG</string>  
+                <string>NDEF</string>
+                <string>TAG</string>
             </array>
         </config-file>
         <config-file parent="com.apple.developer.nfc.readersession.formats" platform="ios" target="*-Release.plist">
             <array>
-                <string>TAG</string>  
+                <string>NDEF</string>
+                <string>TAG</string>
             </array>
         </config-file>
         

--- a/plugin.xml
+++ b/plugin.xml
@@ -122,13 +122,11 @@
         <!-- https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_nfc_readersession_formats?language=objc -->
         <config-file parent="com.apple.developer.nfc.readersession.formats" platform="ios" target="*-Debug.plist">
             <array>
-                <string>NDEF</string>
                 <string>TAG</string>  
             </array>
         </config-file>
         <config-file parent="com.apple.developer.nfc.readersession.formats" platform="ios" target="*-Release.plist">
             <array>
-                <string>NDEF</string>
                 <string>TAG</string>  
             </array>
         </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -26,6 +26,8 @@
             </feature>
         </config-file>
 
+        <source-file src="src/android/src/com/chariotsolutions/nfc/plugin/NfcActivity.java"
+            target-dir="src/com/chariotsolutions/nfc/plugin"/>
         <source-file src="src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java"
             target-dir="src/com/chariotsolutions/nfc/plugin"/>
         <source-file src="src/android/src/com/chariotsolutions/nfc/plugin/Util.java"

--- a/plugin.xml
+++ b/plugin.xml
@@ -122,13 +122,11 @@
         <!-- https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_nfc_readersession_formats?language=objc -->
         <config-file parent="com.apple.developer.nfc.readersession.formats" platform="ios" target="*-Debug.plist">
             <array>
-                <string>NDEF</string>
                 <string>TAG</string>
             </array>
         </config-file>
         <config-file parent="com.apple.developer.nfc.readersession.formats" platform="ios" target="*-Release.plist">
             <array>
-                <string>NDEF</string>
                 <string>TAG</string>
             </array>
         </config-file>

--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcActivity.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcActivity.java
@@ -1,0 +1,48 @@
+package com.chariotsolutions.nfc.plugin;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
+public class NfcActivity extends Activity
+{
+    private static Intent launchIntent = null;
+    private static boolean initialized = false;
+
+    public static final String TAG = "NfcActivity";
+
+    @Override
+    public void onCreate(Bundle savedInstanceState)
+    {
+        super.onCreate(savedInstanceState);
+
+        Log.i(TAG, "onCreate: " + getIntent().getAction());
+        launchIntent = getIntent();
+
+        if (!initialized) {
+            // This looks like a cold start (Cordova has not launched) so send a launch intent
+            final Intent launchIntent = getPackageManager().getLaunchIntentForPackage(getPackageName());
+            if (launchIntent != null) {
+                launchIntent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_NEW_TASK);
+                startActivity(launchIntent);
+            } else {
+                Log.w(TAG, "onCreate: no launch intent defined!");
+            }
+        }
+
+        finish();
+    }
+
+    public static void onPluginInitialize() {
+        Log.i(TAG, "onPluginInitialize");
+        initialized = true;
+    }
+
+    public static Intent getLaunchIntent() {
+        final Intent result = launchIntent;
+        launchIntent = null;
+        Log.i(TAG, "getLaunchIntent: " +  result);
+        return result;
+    }
+}

--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -246,6 +246,7 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
 
             Intent tagIntent = new Intent();
             tagIntent.putExtra(NfcAdapter.EXTRA_TAG, tag);
+            savedIntent = tagIntent;
             setIntent(tagIntent);
 
             PluginResult result = new PluginResult(PluginResult.Status.OK, json);

--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -36,7 +36,7 @@ import android.os.Bundle;
 import android.os.Parcelable;
 import android.util.Log;
 
-public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCompleteCallback {
+public class NfcPlugin extends CordovaPlugin {
     private static final String REGISTER_MIME_TYPE = "registerMimeType";
     private static final String REMOVE_MIME_TYPE = "removeMimeType";
     private static final String REGISTER_NDEF = "registerNdef";
@@ -47,10 +47,6 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
     private static final String WRITE_TAG = "writeTag";
     private static final String MAKE_READ_ONLY = "makeReadOnly";
     private static final String ERASE_TAG = "eraseTag";
-    private static final String SHARE_TAG = "shareTag";
-    private static final String UNSHARE_TAG = "unshareTag";
-    private static final String HANDOVER = "handover"; // Android Beam
-    private static final String STOP_HANDOVER = "stopHandover";
     private static final String ENABLED = "enabled";
     private static final String INIT = "init";
     private static final String SHOW_SETTINGS = "showSettings";
@@ -82,15 +78,12 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
     private final List<IntentFilter> intentFilters = new ArrayList<>();
     private final ArrayList<String[]> techLists = new ArrayList<>();
 
-    private NdefMessage p2pMessage = null;
     private PendingIntent pendingIntent = null;
 
     private Intent savedIntent = null;
 
     private CallbackContext readerModeCallback;
     private CallbackContext channelCallback;
-    private CallbackContext shareTagCallback;
-    private CallbackContext handoverCallback;
 
     @Override
     public boolean execute(String action, JSONArray data, CallbackContext callbackContext) throws JSONException {
@@ -156,18 +149,6 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
 
         } else if (action.equalsIgnoreCase(ERASE_TAG)) {
             eraseTag(callbackContext);
-
-        } else if (action.equalsIgnoreCase(SHARE_TAG)) {
-            shareTag(data, callbackContext);
-
-        } else if (action.equalsIgnoreCase(UNSHARE_TAG)) {
-            unshareTag(callbackContext);
-
-        } else if (action.equalsIgnoreCase(HANDOVER)) {
-            handover(data, callbackContext);
-
-        } else if (action.equalsIgnoreCase(STOP_HANDOVER)) {
-            stopHandover(callbackContext);
 
         } else if (action.equalsIgnoreCase(INIT)) {
             init(callbackContext);
@@ -298,13 +279,6 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
     private void removeNdef(CallbackContext callbackContext) {
         removeTechList(new String[]{Ndef.class.getName()});
         restartNfc();
-        callbackContext.success();
-    }
-
-    private void unshareTag(CallbackContext callbackContext) {
-        p2pMessage = null;
-        stopNdefPush();
-        shareTagCallback = null;
         callbackContext.success();
     }
 
@@ -503,35 +477,6 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
         });
     }
 
-    private void shareTag(JSONArray data, CallbackContext callbackContext) throws JSONException {
-        NdefRecord[] records = Util.jsonToNdefRecords(data.getString(0));
-        this.p2pMessage = new NdefMessage(records);
-
-        startNdefPush(callbackContext);
-    }
-
-    // setBeamPushUris
-    // Every Uri you provide must have either scheme 'file' or scheme 'content'.
-    // Note that this takes priority over setNdefPush
-    //
-    // See http://developer.android.com/reference/android/nfc/NfcAdapter.html#setBeamPushUris(android.net.Uri[],%20android.app.Activity)
-    private void handover(JSONArray data, CallbackContext callbackContext) throws JSONException {
-
-        Uri[] uri = new Uri[data.length()];
-
-        for (int i = 0; i < data.length(); i++) {
-            uri[i] = Uri.parse(data.getString(i));
-        }
-
-        startNdefBeam(callbackContext, uri);
-    }
-
-    private void stopHandover(CallbackContext callbackContext) {
-        stopNdefBeam();
-        handoverCallback = null;
-        callbackContext.success();
-    }
-
     private void showSettings(CallbackContext callbackContext) {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
             Intent intent = new Intent(android.provider.Settings.ACTION_NFC_SETTINGS);
@@ -616,10 +561,6 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
                     if (intentFilters.length > 0 || techLists.length > 0) {
                         nfcAdapter.enableForegroundDispatch(getActivity(), getPendingIntent(), intentFilters, techLists);
                     }
-
-                    if (p2pMessage != null) {
-                        nfcAdapter.setNdefPushMessage(p2pMessage, getActivity());
-                    }
                 } catch (IllegalStateException e) {
                     // issue 110 - user exits app with home button while nfc is initializing
                     Log.w(TAG, "Illegal State Exception starting NFC. Assuming application is terminating.");
@@ -643,77 +584,6 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
                     Log.w(TAG, "Illegal State Exception stopping NFC. Assuming application is terminating.");
                 }
             }
-        });
-    }
-
-    private void startNdefBeam(final CallbackContext callbackContext, final Uri[] uris) {
-        getActivity().runOnUiThread(() -> {
-
-            NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(getActivity());
-
-            if (nfcAdapter == null) {
-                callbackContext.error(STATUS_NO_NFC);
-            } else if (!nfcAdapter.isNdefPushEnabled()) {
-                callbackContext.error(STATUS_NDEF_PUSH_DISABLED);
-            } else {
-                nfcAdapter.setOnNdefPushCompleteCallback(NfcPlugin.this, getActivity());
-                try {
-                    nfcAdapter.setBeamPushUris(uris, getActivity());
-
-                    PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
-                    result.setKeepCallback(true);
-                    handoverCallback = callbackContext;
-                    callbackContext.sendPluginResult(result);
-
-                } catch (IllegalArgumentException e) {
-                    callbackContext.error(e.getMessage());
-                }
-            }
-        });
-    }
-
-    private void startNdefPush(final CallbackContext callbackContext) {
-        getActivity().runOnUiThread(() -> {
-
-            NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(getActivity());
-
-            if (nfcAdapter == null) {
-                callbackContext.error(STATUS_NO_NFC);
-            } else if (!nfcAdapter.isNdefPushEnabled()) {
-                callbackContext.error(STATUS_NDEF_PUSH_DISABLED);
-            } else {
-                nfcAdapter.setNdefPushMessage(p2pMessage, getActivity());
-                nfcAdapter.setOnNdefPushCompleteCallback(NfcPlugin.this, getActivity());
-
-                PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
-                result.setKeepCallback(true);
-                shareTagCallback = callbackContext;
-                callbackContext.sendPluginResult(result);
-            }
-        });
-    }
-
-    private void stopNdefPush() {
-        getActivity().runOnUiThread(() -> {
-
-            NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(getActivity());
-
-            if (nfcAdapter != null) {
-                nfcAdapter.setNdefPushMessage(null, getActivity());
-            }
-
-        });
-    }
-
-    private void stopNdefBeam() {
-        getActivity().runOnUiThread(() -> {
-
-            NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(getActivity());
-
-            if (nfcAdapter != null) {
-                nfcAdapter.setBeamPushUris(null, getActivity());
-            }
-
         });
     }
 
@@ -904,22 +774,6 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
 
     private void setIntent(Intent intent) {
         getActivity().setIntent(intent);
-    }
-
-    @Override
-    public void onNdefPushComplete(NfcEvent event) {
-
-        // handover (beam) take precedence over share tag (ndef push)
-        if (handoverCallback != null) {
-            PluginResult result = new PluginResult(PluginResult.Status.OK, "Beamed Message to Peer");
-            result.setKeepCallback(true);
-            handoverCallback.sendPluginResult(result);
-        } else if (shareTagCallback != null) {
-            PluginResult result = new PluginResult(PluginResult.Status.OK, "Shared Message with Peer");
-            result.setKeepCallback(true);
-            shareTagCallback.sendPluginResult(result);
-        }
-
     }
 
     /**

--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -31,6 +31,7 @@ import android.nfc.TagLostException;
 import android.nfc.tech.Ndef;
 import android.nfc.tech.NdefFormatable;
 import android.nfc.tech.TagTechnology;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.util.Log;
@@ -531,7 +532,13 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
             Activity activity = getActivity();
             Intent intent = new Intent(activity, activity.getClass());
             intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            pendingIntent = PendingIntent.getActivity(activity, 0, intent, 0);
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                pendingIntent = PendingIntent.getActivity(activity, 0, intent, PendingIntent.FLAG_MUTABLE);
+            } else {
+                intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                pendingIntent = PendingIntent.getActivity(activity, 0, intent, 0);
+            }
         }
     }
 

--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -644,9 +644,12 @@ public class NfcPlugin extends CordovaPlugin {
             Tag tag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
             Parcelable[] messages = intent.getParcelableArrayExtra((NfcAdapter.EXTRA_NDEF_MESSAGES));
 
+            boolean isNfcIntent = false;
+
             if (action.equals(NfcAdapter.ACTION_NDEF_DISCOVERED)) {
                 Ndef ndef = Ndef.get(tag);
                 fireNdefEvent(NDEF_MIME, ndef, messages);
+                isNfcIntent = true;
 
             } else if (action.equals(NfcAdapter.ACTION_TECH_DISCOVERED)) {
                 for (String tagTech : tag.getTechList()) {
@@ -658,13 +661,20 @@ public class NfcPlugin extends CordovaPlugin {
                         fireNdefEvent(NDEF, ndef, messages);
                     }
                 }
+                isNfcIntent = true;
             }
 
             if (action.equals(NfcAdapter.ACTION_TAG_DISCOVERED)) {
                 fireTagEvent(tag);
+                isNfcIntent = true;
             }
 
-            setIntent(new Intent());
+            // Only clear the intent if it was an NFC intent that we consumed.
+            // Clearing non-NFC intents (e.g. ACTION_VIEW from widget taps) breaks
+            // other plugins that read the launch intent later.
+            if (isNfcIntent) {
+                setIntent(new Intent());
+            }
         });
     }
 

--- a/src/ios/NfcPlugin.h
+++ b/src/ios/NfcPlugin.h
@@ -11,15 +11,25 @@
 #import <CoreNFC/CoreNFC.h>
 #import <WebKit/WebKit.h>
 
+#import "AppDelegate.h"
+
 @interface NfcPlugin : CDVPlugin <NFCNDEFReaderSessionDelegate, NFCTagReaderSessionDelegate> {
 }
 
 // iOS Specific API
 
+// Cordova lifecycle events
+- (void) onPause;
+- (void) onResume;
+
 // deprecated use scanNdef or scanTag
 - (void)beginSession:(CDVInvokedUrlCommand *)command;
 // deprecated use stopScan
 - (void)invalidateSession:(CDVInvokedUrlCommand *)command;
+
+// Handle launch data
+- (void)parseLaunchIntent:(CDVInvokedUrlCommand *)command;
+- (void)messageReceived:(NFCNDEFMessage *)message;
 
 // Added iOS 13
 - (void)scanNdef:(CDVInvokedUrlCommand *)command;
@@ -35,6 +45,11 @@
 // Internal implementation
 - (void)channel:(CDVInvokedUrlCommand *)command;
 
+@end
+
+@interface AppDelegate (nfcDelegate)
+    - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *))restorationHandler ;
+    @property (nonatomic, strong) IBOutlet NSUserActivity* userActivity;
 @end
 
 #endif

--- a/src/ios/NfcPlugin.h
+++ b/src/ios/NfcPlugin.h
@@ -47,9 +47,8 @@
 
 @end
 
-@interface AppDelegate (nfcDelegate)
-    - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *))restorationHandler ;
-    @property (nonatomic, strong) IBOutlet NSUserActivity* userActivity;
+@interface AppDelegate (PhonegapNfc)
+    - (BOOL)application:(UIApplication *)application swizzledContinueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *))restorationHandler ;
 @end
 
 #endif

--- a/src/ios/NfcPlugin.h
+++ b/src/ios/NfcPlugin.h
@@ -30,6 +30,7 @@
 // Handle launch data
 - (void)parseLaunchIntent:(CDVInvokedUrlCommand *)command;
 - (void)messageReceived:(NFCNDEFMessage *)message;
+- (void)urlReceived:(NSString *)urlString;
 
 // Added iOS 13
 - (void)scanNdef:(CDVInvokedUrlCommand *)command;

--- a/src/ios/NfcPlugin.m
+++ b/src/ios/NfcPlugin.m
@@ -215,13 +215,13 @@ swizzledContinueUserActivity:(NSUserActivity *)userActivity
         if (self.shouldUseTagReaderSession) {
             NSLog(@"Using NFCTagReaderSession");
 
-            self.nfcSession = [[NFCTagReaderSession new]
+            self.nfcSession = [[NFCTagReaderSession alloc]
                        initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693 | NFCPollingISO18092)
                        delegate:self queue:dispatch_get_main_queue()];
 
         } else {
             NSLog(@"Using NFCTagReaderSession");
-            self.nfcSession = [[NFCNDEFReaderSession new]initWithDelegate:self queue:nil invalidateAfterFirstRead:FALSE];
+            self.nfcSession = [[NFCNDEFReaderSession alloc]initWithDelegate:self queue:nil invalidateAfterFirstRead:FALSE];
         }
     }
 
@@ -400,12 +400,12 @@ swizzledContinueUserActivity:(NSUserActivity *)userActivity
         
         if (self.shouldUseTagReaderSession) {
             NSLog(@"Using NFCTagReaderSession");
-            self.nfcSession = [[NFCTagReaderSession new]
+            self.nfcSession = [[NFCTagReaderSession alloc]
                            initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693 | NFCPollingISO18092)
                            delegate:self queue:dispatch_get_main_queue()];
         } else {
             NSLog(@"Using NFCNDEFReaderSession");
-            self.nfcSession = [[NFCNDEFReaderSession new]initWithDelegate:self queue:nil invalidateAfterFirstRead:TRUE];
+            self.nfcSession = [[NFCNDEFReaderSession alloc]initWithDelegate:self queue:nil invalidateAfterFirstRead:TRUE];
         }
         sessionCallbackId = [command.callbackId copy];
         self.nfcSession.alertMessage = @"Hold near NFC tag to scan.";
@@ -413,7 +413,7 @@ swizzledContinueUserActivity:(NSUserActivity *)userActivity
         
     } else if (@available(iOS 11.0, *)) {
         NSLog(@"iOS < 13, using NFCNDEFReaderSession");
-        self.nfcSession = [[NFCNDEFReaderSession new]initWithDelegate:self queue:nil invalidateAfterFirstRead:TRUE];
+        self.nfcSession = [[NFCNDEFReaderSession alloc]initWithDelegate:self queue:nil invalidateAfterFirstRead:TRUE];
         sessionCallbackId = [command.callbackId copy];
         self.nfcSession.alertMessage = @"Hold near NFC tag to scan.";
         [self.nfcSession beginSession];

--- a/src/ios/NfcPlugin.m
+++ b/src/ios/NfcPlugin.m
@@ -216,7 +216,7 @@ swizzledContinueUserActivity:(NSUserActivity *)userActivity
             NSLog(@"Using NFCTagReaderSession");
 
             self.nfcSession = [[NFCTagReaderSession new]
-                       initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693)
+                       initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693 | NFCPollingISO18092)
                        delegate:self queue:dispatch_get_main_queue()];
 
         } else {
@@ -401,7 +401,7 @@ swizzledContinueUserActivity:(NSUserActivity *)userActivity
         if (self.shouldUseTagReaderSession) {
             NSLog(@"Using NFCTagReaderSession");
             self.nfcSession = [[NFCTagReaderSession new]
-                           initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693)
+                           initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693 | NFCPollingISO18092)
                            delegate:self queue:dispatch_get_main_queue()];
         } else {
             NSLog(@"Using NFCNDEFReaderSession");

--- a/src/ios/NfcPlugin.m
+++ b/src/ios/NfcPlugin.m
@@ -5,6 +5,50 @@
 //  (c) 2107-2020 Don Coleman
 
 #import "NfcPlugin.h"
+#import <objc/runtime.h>
+
+static void * UserActivityPropertyKey = &UserActivityPropertyKey;
+static NFCNDEFMessage * LaunchMessage = nil;
+static NfcPlugin* Listener = nil;
+
+@implementation AppDelegate (nfcDelegate)
+
+- (NSUserActivity *)userActivity {
+    return objc_getAssociatedObject(self, UserActivityPropertyKey);
+}
+
+- (void)setUserActivity:(NSUserActivity *)activity {
+    objc_setAssociatedObject(self, UserActivityPropertyKey, activity, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (BOOL)application:(UIApplication *)application
+continueUserActivity:(NSUserActivity *)userActivity
+ restorationHandler:(void (^)(NSArray *))restorationHandler {
+    if (@available(iOS 12, *)) {
+        if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb])
+        {
+            NFCNDEFMessage *messagePayload = userActivity.ndefMessagePayload;
+            if (messagePayload.records.count > 0 && messagePayload.records[0].typeNameFormat != NFCTypeNameFormatEmpty)
+            {
+                NSLog(@"nfcDelegate - received NDEF message");
+                if (Listener != nil)
+                {
+                    [Listener messageReceived:messagePayload];
+                }
+                else
+                {
+                    LaunchMessage = messagePayload;
+                }
+                self.userActivity = userActivity;
+                return YES;
+            }
+        }
+    }
+
+    return NO;
+}
+
+@end
 
 @interface NfcPlugin() {
     NSString* sessionCallbackId;
@@ -20,6 +64,7 @@
 @property (nonatomic, assign) BOOL keepSessionOpen;
 @property (strong, nonatomic) NFCReaderSession *nfcSession API_AVAILABLE(ios(11.0));
 @property (strong, nonatomic) NFCNDEFMessage *messageToWrite API_AVAILABLE(ios(11.0));
+@property BOOL hasListener;
 @end
 
 @implementation NfcPlugin
@@ -46,6 +91,54 @@
     // the channel is used to send NFC tag data to the web view
     channelCallbackId = [command.callbackId copy];
 }
+
+- (void)onPause {
+    Listener = nil;
+}
+
+- (void)onResume {
+    if (self.hasListener) {
+        Listener = self;
+    }
+}
+
+- (void)parseLaunchIntent:(CDVInvokedUrlCommand *)command {
+    NSLog(@"parseLaunchIntent");
+
+    NFCNDEFMessage* ndefMessage = LaunchMessage;
+    LaunchMessage = nil;
+    
+    CDVPluginResult* pluginResult;
+    
+    if (ndefMessage == nil)
+    {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"NO_INTENT"];
+    }
+    else
+    {
+        NSDictionary* parsedMessage = [self buildTagDictionary:ndefMessage metaData:nil];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:parsedMessage];
+    }
+    
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void)messageReceived:(NFCNDEFMessage *)ndefMessage {
+    NSLog(@"messageReceived");
+
+    NSMutableDictionary *nfcEvent = [NSMutableDictionary new];
+    nfcEvent[@"type"] = @"ndef";
+    nfcEvent[@"tag"] = [self buildTagDictionary:ndefMessage metaData:nil];
+
+    if (channelCallbackId) {
+        NSLog(@"Sending NFC data via channelCallbackId so an NDEF event fires)");
+        
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:nfcEvent];
+        [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:channelCallbackId];
+    }
+}
+
 
 - (void)beginSession:(CDVInvokedUrlCommand*)command {
     NSLog(@"beginSession");
@@ -172,6 +265,8 @@
 // Nothing happens here, the event listener is registered in JavaScript
 - (void)registerNdef:(CDVInvokedUrlCommand *)command {
     NSLog(@"registerNdef");
+    self.hasListener = TRUE;
+    Listener = self;
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -179,6 +274,8 @@
 // Nothing happens here, the event listener is removed in JavaScript
 - (void)removeNdef:(CDVInvokedUrlCommand *)command {
     NSLog(@"removeNdef");
+    self.hasListener = FALSE;
+    Listener = nil;
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }

--- a/src/ios/NfcPlugin.m
+++ b/src/ios/NfcPlugin.m
@@ -216,7 +216,7 @@ swizzledContinueUserActivity:(NSUserActivity *)userActivity
             NSLog(@"Using NFCTagReaderSession");
 
             self.nfcSession = [[NFCTagReaderSession alloc]
-                       initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693 | NFCPollingISO18092)
+                       initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693)
                        delegate:self queue:dispatch_get_main_queue()];
 
         } else {
@@ -401,7 +401,7 @@ swizzledContinueUserActivity:(NSUserActivity *)userActivity
         if (self.shouldUseTagReaderSession) {
             NSLog(@"Using NFCTagReaderSession");
             self.nfcSession = [[NFCTagReaderSession alloc]
-                           initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693 | NFCPollingISO18092)
+                           initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693)
                            delegate:self queue:dispatch_get_main_queue()];
         } else {
             NSLog(@"Using NFCNDEFReaderSession");

--- a/src/ios/NfcPlugin.m
+++ b/src/ios/NfcPlugin.m
@@ -9,6 +9,7 @@
 
 static void * UserActivityPropertyKey = &UserActivityPropertyKey;
 static NFCNDEFMessage * LaunchMessage = nil;
+static NSString * LaunchURL = nil;
 static NfcPlugin* Listener = nil;
 
 @implementation AppDelegate (PhonegapNfc)
@@ -38,6 +39,29 @@ swizzledContinueUserActivity:(NSUserActivity *)userActivity
                     LaunchMessage = messagePayload;
                 }
                 return YES;
+            }
+            // Fallback — Universal Link without NDEF payload.
+            // This happens when the URL is opened via simctl, Safari, or another app
+            // rather than from an NFC tag scan. The URL still contains the tag ID
+            // (in the fragment) and name (in the query param), so NfcTag can parse it.
+            else
+            {
+                NSURL *webpageURL = userActivity.webpageURL;
+                if (webpageURL != nil)
+                {
+                    NSString *urlString = webpageURL.absoluteString;
+                    NSLog(@"nfcDelegate - received Universal Link without NDEF: %@", urlString);
+                    if (Listener != nil)
+                    {
+                        [Listener urlReceived:urlString];
+                    }
+                    else
+                    {
+                        // Cold start — buffer for parseLaunchIntent.
+                        LaunchURL = urlString;
+                    }
+                    return YES;
+                }
             }
         }
     }
@@ -104,19 +128,27 @@ swizzledContinueUserActivity:(NSUserActivity *)userActivity
 
     NFCNDEFMessage* ndefMessage = LaunchMessage;
     LaunchMessage = nil;
-    
+    NSString* launchURL = LaunchURL;
+    LaunchURL = nil;
+
     CDVPluginResult* pluginResult;
-    
-    if (ndefMessage == nil)
-    {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"NO_INTENT"];
-    }
-    else
+
+    if (ndefMessage != nil)
     {
         NSDictionary* parsedMessage = [self buildTagDictionary:ndefMessage metaData:nil];
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:parsedMessage];
     }
-    
+    else if (launchURL != nil)
+    {
+        // URL string fallback — same as Android's getDataString() path.
+        // NfcTag JS constructor accepts strings.
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:launchURL];
+    }
+    else
+    {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"NO_INTENT"];
+    }
+
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
@@ -129,7 +161,25 @@ swizzledContinueUserActivity:(NSUserActivity *)userActivity
 
     if (channelCallbackId) {
         NSLog(@"Sending NFC data via channelCallbackId so an NDEF event fires)");
-        
+
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:nfcEvent];
+        [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:channelCallbackId];
+    }
+}
+
+- (void)urlReceived:(NSString *)urlString {
+    NSLog(@"urlReceived: %@", urlString);
+
+    // Send URL string through the channel callback as an NDEF event.
+    // JS NfcTag constructor accepts strings and parses the URI.
+    NSMutableDictionary *nfcEvent = [NSMutableDictionary new];
+    nfcEvent[@"type"] = @"ndef";
+    nfcEvent[@"tag"] = urlString;
+
+    if (channelCallbackId) {
+        NSLog(@"Sending URL via channelCallbackId so an NDEF event fires");
+
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:nfcEvent];
         [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:channelCallbackId];

--- a/www/phonegap-nfc.js
+++ b/www/phonegap-nfc.js
@@ -500,6 +500,10 @@ var nfc = {
         cordova.exec(win, fail, "NfcPlugin", "showSettings", []);
     },
 
+    parseLaunchIntent: function (win, fail) {
+            cordova.exec(win, fail, "NfcPlugin", "parseLaunchIntent", []);
+    },
+
     // iOS only - scan for NFC NDEF tag using NFCNDEFReaderSession
     scanNdef: function (options) {
         return new Promise(function(resolve, reject) {


### PR DESCRIPTION
Changes related to background launch:

* [iOS] Add documentation detailing how to configure the app to support launch from background using applinks
* [Android and iOS] Remember the NFC message/intent that caused the OS to start the application so it can be queried later during the `deviceready` or `onresume` application events.
* [iOS] If the app was already in the foreground when the tag was scanned, and the app registered an `ndefListener`,  pass the NDEF messages to the listener directly

Additional bug fixes

* [Android] Fix a bug whereas writing a tag fails because `savedIntent` is not set on the reader callback during an NFC reader session.

Caveats:

* [iOS] The information available during background launch does not include tag metadata, only the NDEF message.