### PR TITLE
Allow ISO 18092 tags

### DIFF
--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -482,8 +482,13 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
         if (pendingIntent == null) {
             Activity activity = getActivity();
             Intent intent = new Intent(activity, activity.getClass());
-            intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            pendingIntent = PendingIntent.getActivity(activity, 0, intent, 0);
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                pendingIntent = PendingIntent.getActivity(activity, 0, intent, PendingIntent.FLAG_MUTABLE);
+            } else {
+                intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                pendingIntent = PendingIntent.getActivity(activity, 0, intent, 0);
+            }
         }
     }
 

--- a/src/ios/NfcPlugin.m
+++ b/src/ios/NfcPlugin.m
@@ -126,7 +126,7 @@
             NSLog(@"Using NFCTagReaderSession");
 
             self.nfcSession = [[NFCTagReaderSession new]
-                       initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693)
+                       initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693 | NFCPollingISO18092)
                        delegate:self queue:dispatch_get_main_queue()];
 
         } else {
@@ -307,7 +307,7 @@
         if (self.shouldUseTagReaderSession) {
             NSLog(@"Using NFCTagReaderSession");
             self.nfcSession = [[NFCTagReaderSession new]
-                           initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693)
+                           initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693 | NFCPollingISO18092)
                            delegate:self queue:dispatch_get_main_queue()];
         } else {
             NSLog(@"Using NFCNDEFReaderSession");


### PR DESCRIPTION
Added NFCPollingISO18092 to polling options to allow scanning of these kinds of tags.

This addresses issue https://github.com/chariotsolutions/phonegap-nfc/issues/468 and has been tested on iPhone 8, 10 and 12