### PR TITLE
Android 12 PendingIntent Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Makefile
 *.iml
 .project
 out/
+.vs/

--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -482,8 +482,13 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
         if (pendingIntent == null) {
             Activity activity = getActivity();
             Intent intent = new Intent(activity, activity.getClass());
-            intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            pendingIntent = PendingIntent.getActivity(activity, 0, intent, 0);
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                pendingIntent = PendingIntent.getActivity(activity, 0, intent, PendingIntent.FLAG_MUTABLE);
+            } else {
+                intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                pendingIntent = PendingIntent.getActivity(activity, 0, intent, 0);
+            }
         }
     }
 


### PR DESCRIPTION
Android 12 is known to crash on launch if the Intent flag is not explicitly set to MUTABLE or IMMUTABLE.

Upon further testing, NFC tags would not scan when the App is in focus when the flag is set to IMMUTABLE. I decided to use the MUTABLE flag instead which is the default flag for a PendingIntent activity and NFC tags scan as normal.

[https://developer.android.com/reference/android/app/PendingIntent#FLAG_MUTABLE](https://developer.android.com/reference/android/app/PendingIntent#FLAG_MUTABLE)
_"Up until Build.VERSION_CODES.R, PendingIntents are **assumed to be mutable by default**, unless FLAG_IMMUTABLE is set. Starting with Build.VERSION_CODES.S, it will be required to explicitly specify the mutability of PendingIntents on creation with either FLAG_IMMUTABLE or FLAG_MUTABLE"_